### PR TITLE
Fix LiteRT conversation handoff and cancel-time native session race

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    testOptions {
+        // Guard tests exercise objects that touch android.util.Log via XLog;
+        // return defaults instead of throwing "not mocked".
+        unitTests.isReturnDefaultValues = true
+    }
+
     buildFeatures {
         buildConfig = true
         compose = true

--- a/app/src/main/java/io/agents/pokeclaw/AppViewModel.kt
+++ b/app/src/main/java/io/agents/pokeclaw/AppViewModel.kt
@@ -55,9 +55,12 @@ class AppViewModel : ViewModel() {
         agentPromptOverride: String? = null,
         onEvent: (TaskEvent) -> Unit,
     ) {
+        // FIX 2 — fence the chat side before onBeforeTask / the orchestrator runs.
+        io.agents.pokeclaw.agent.llm.EngineHolder.markTaskStarting()
         onBeforeTask?.invoke()
         taskOrchestrator.taskEventCallback = onEvent
         if (!updateAgentConfig()) {
+            io.agents.pokeclaw.agent.llm.EngineHolder.clearTaskStarting()
             onEvent(TaskEvent.Failed("AI service not ready"))
             return
         }

--- a/app/src/main/java/io/agents/pokeclaw/TaskOrchestrator.kt
+++ b/app/src/main/java/io/agents/pokeclaw/TaskOrchestrator.kt
@@ -78,14 +78,23 @@ class TaskOrchestrator(
     // ==================== Task Lock ====================
 
     fun tryAcquireTask(messageId: String, channel: Channel, taskText: String = ""): Boolean {
-        return taskSessionStore.tryAcquire(
+        val acquired = taskSessionStore.tryAcquire(
             messageId = messageId,
             channel = channel,
             taskText = taskText,
         )
+        // FIX 2 — task lock held: TaskSessionStore.isTaskRunning() is now the
+        // authoritative fence, so the short-lived "starting" flag can stand down.
+        if (acquired) io.agents.pokeclaw.agent.llm.EngineHolder.clearTaskStarting()
+        return acquired
     }
 
-    private fun releaseTask(): TaskSessionState = taskSessionStore.release()
+    private fun releaseTask(): TaskSessionState {
+        // FIX 2 — every task terminal (COMPLETE / FAILED / CANCELLED / BLOCKED)
+        // funnels through here — clear the fence unconditionally.
+        io.agents.pokeclaw.agent.llm.EngineHolder.clearTaskStarting()
+        return taskSessionStore.release()
+    }
 
     fun isTaskRunning(): Boolean = taskSessionStore.isTaskRunning()
 

--- a/app/src/main/java/io/agents/pokeclaw/agent/llm/EngineHolder.kt
+++ b/app/src/main/java/io/agents/pokeclaw/agent/llm/EngineHolder.kt
@@ -27,6 +27,81 @@ object EngineHolder {
     private var currentModelPath: String? = null
     private var currentBackendLabel: String? = null
 
+    // ------------------------------------------------------------------
+    // Session-handoff experiment (fix/experiment: serialize local model session handoff)
+    // ------------------------------------------------------------------
+
+    /**
+     * FIX 1 — Conversation-slot mutex.
+     *
+     * LiteRT-LM allows exactly ONE live [com.google.ai.edge.litertlm.Conversation]
+     * per [Engine]. The chat owner (ChatSessionController) and the task owner
+     * (LocalLlmClient) each keep their own Conversation on this one shared engine.
+     * Without serialisation, the chat executor and the task executor can both reach
+     * `engine.createConversation()` at the same moment and one gets
+     * `FAILED_PRECONDITION: A session already exists`.
+     *
+     * Hold this lock ONLY around session lifecycle — "close old Conversation" +
+     * "open new Conversation". NEVER hold it during sendMessage / prefill / decode.
+     */
+    private val conversationSlotLock = Any()
+
+    fun <T> withConversationSlot(block: () -> T): T =
+        synchronized(conversationSlotLock) {
+            XLog.d(TAG, "[SESSION] CONVERSATION_SLOT_ACQUIRE")
+            try {
+                block()
+            } finally {
+                XLog.d(TAG, "[SESSION] CONVERSATION_SLOT_RELEASE")
+            }
+        }
+
+    /**
+     * FIX 2 — "task active or starting" fence (starting-window half).
+     *
+     * A task launch can bring ComposeChatActivity to the foreground, whose
+     * `onResume()` would otherwise (re)open a chat Conversation on the shared
+     * engine right as the task opens its own. `isTaskRunning()` (TaskSessionStore)
+     * only becomes true once the orchestrator has acquired the task lock — too late
+     * to fence the initial `onResume`. This flag covers the launch -> acquire gap.
+     *
+     * Cleared by the orchestrator once `isTaskRunning()` takes over, and again at
+     * task terminal. Auto-expires after [TASK_STARTING_GRACE_MS] so a launch that
+     * never reaches startTask cannot wedge the chat side forever.
+     */
+    internal const val TASK_STARTING_GRACE_MS = 15_000L
+
+    @Volatile
+    private var taskStartingAtMs = 0L
+
+    /** Pure, unit-testable expiry check. */
+    internal fun startingFenceActive(startedAtMs: Long, nowMs: Long): Boolean {
+        if (startedAtMs == 0L) return false
+        val age = nowMs - startedAtMs
+        return age in 0L until TASK_STARTING_GRACE_MS
+    }
+
+    fun markTaskStarting() {
+        taskStartingAtMs = System.currentTimeMillis()
+        XLog.i(TAG, "[SESSION] TASK_ACTIVE_OR_STARTING=true (starting)")
+    }
+
+    fun clearTaskStarting() {
+        if (taskStartingAtMs != 0L) {
+            taskStartingAtMs = 0L
+            XLog.i(TAG, "[SESSION] TASK_ACTIVE_OR_STARTING=false (starting cleared)")
+        }
+    }
+
+    fun isTaskStarting(): Boolean {
+        val startedAt = taskStartingAtMs
+        if (startedAt == 0L) return false
+        if (startingFenceActive(startedAt, System.currentTimeMillis())) return true
+        taskStartingAtMs = 0L
+        XLog.w(TAG, "[SESSION] task-starting fence expired — auto-cleared")
+        return false
+    }
+
     private fun backendLabel(backend: Backend): String =
         if (backend is Backend.CPU) "CPU" else if (backend is Backend.GPU) "GPU" else backend.javaClass.simpleName
 

--- a/app/src/main/java/io/agents/pokeclaw/agent/llm/LocalLlmClient.kt
+++ b/app/src/main/java/io/agents/pokeclaw/agent/llm/LocalLlmClient.kt
@@ -44,6 +44,84 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
 
     private var gpuFailed = false
 
+    // ------------------------------------------------------------------
+    // Cancel-safe close (experiment/pokeclaw-cancel-safe-close)
+    //
+    // Bug: DefaultAgentService.cancel()/updateConfig()/shutdown() can call close()
+    // (→ Conversation.close() → nativeDeleteConversation) from another thread while
+    // the agent-loop thread is still inside Conversation.sendMessage → nativeSendMessage.
+    // LiteRT-LM's native send is NOT interrupt-safe → use-after-free → SIGSEGV.
+    //
+    // Guard: track in-flight native sends per client. close() flips `closing`,
+    // rejects new sends, and waits (bounded) for in-flight sends to drain before
+    // it ever calls nativeDeleteConversation. On timeout it fails closed — the
+    // native conversation is left alive rather than freed under an active send.
+    // ------------------------------------------------------------------
+    private val sendLifecycleLock = Object()
+    @Volatile private var closing = false
+    private var inFlightSendCount = 0
+    private var closeDeferred = false
+
+    // test hooks (same module only)
+    internal val inFlightSends: Int get() = synchronized(sendLifecycleLock) { inFlightSendCount }
+    internal val isClosing: Boolean get() = closing
+    internal val isCloseDeferred: Boolean get() = synchronized(sendLifecycleLock) { closeDeferred }
+
+    /** Reserve a send slot. Throws if the client is closing so the loop stops. */
+    internal fun beginSend() {
+        synchronized(sendLifecycleLock) {
+            if (closing) throw IllegalStateException("[SEND-GUARD] LocalLlmClient is closing — send rejected")
+            inFlightSendCount++
+            XLog.i(TAG, "[SEND-GUARD] SEND_ENTER inFlight=$inFlightSendCount")
+        }
+    }
+
+    /**
+     * Release a send slot. If a close() came in while this send was running, the
+     * close was deferred — perform the real native close now, on this (loop) thread,
+     * where it can never overlap a send.
+     */
+    internal fun endSend() {
+        val runDeferredClose: Boolean
+        synchronized(sendLifecycleLock) {
+            if (inFlightSendCount > 0) inFlightSendCount--
+            XLog.i(TAG, "[SEND-GUARD] SEND_EXIT inFlight=$inFlightSendCount")
+            if (inFlightSendCount == 0) sendLifecycleLock.notifyAll()
+            runDeferredClose = closeDeferred && inFlightSendCount == 0
+            if (runDeferredClose) closeDeferred = false
+        }
+        if (runDeferredClose) {
+            XLog.i(TAG, "[SEND-GUARD] running deferred close after last send drained")
+            closeConversationNative()
+        }
+    }
+
+    private inline fun <T> guardedSend(block: () -> T): T {
+        beginSend()
+        try {
+            return block()
+        } finally {
+            endSend()
+        }
+    }
+
+    /** Set once the native conversation has actually been torn down. Test hook. */
+    @Volatile internal var closeExecuted = false
+        private set
+
+    /** The actual native teardown — only ever called with inFlightSendCount == 0. */
+    private fun closeConversationNative() {
+        EngineHolder.withConversationSlot {
+            XLog.i(TAG, "[SESSION] SESSION_OWNER=TASK CONVERSATION_CLOSE")
+            try { conversation?.close() } catch (e: Exception) { XLog.w(TAG, "close conversation error", e) }
+            conversation = null
+            engine = null
+            processedMessageCount = 0
+        }
+        closeExecuted = true
+        XLog.i(TAG, "[SEND-GUARD] CLOSE_EXECUTED")
+    }
+
     private fun ensureEngine() {
         val modelPath = config.baseUrl
         val context = ClawApplication.instance
@@ -191,7 +269,7 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
                     val conv = conversation ?: throw RuntimeException("LiteRT-LM conversation not initialized — engine may have failed to load the model")
                     XLog.d(TAG, "chat: sendMessage user (${msg.singleText().take(80)}...) sendCount=$sendCount")
                     try {
-                        lastResponse = conv.sendMessage(msg.singleText())
+                        lastResponse = guardedSend { conv.sendMessage(msg.singleText()) }
                     } catch (e: Exception) {
                         // LiteRT-LM SDK may fail to parse tool calls with standard quotes.
                         // Extract raw model output from error message and parse ourselves.
@@ -216,7 +294,7 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
                     val conv = conversation ?: throw RuntimeException("LiteRT-LM conversation not initialized — engine may have failed to load the model")
                     XLog.d(TAG, "chat: sendMessage toolResult (${toolResultText.take(80)}...) sendCount=$sendCount")
                     try {
-                        lastResponse = conv.sendMessage(toolResultText)
+                        lastResponse = guardedSend { conv.sendMessage(toolResultText) }
                     } catch (e: Exception) {
                         val errorMsg = e.message ?: ""
                         if (errorMsg.contains("Failed to parse tool calls") && errorMsg.contains("tool_call")) {
@@ -541,20 +619,57 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
         }
     }
 
-    override fun close() {
+    override fun close() = close(CLOSE_WAIT_TIMEOUT_MS)
+
+    /**
+     * Cancel-safe close.
+     *   1. flip `closing` — no new native send can start (beginSend throws).
+     *   2. if a send is in flight, DEFER the native teardown: endSend() on the
+     *      loop thread runs it once the last send drains. close() never calls
+     *      nativeDeleteConversation under an active nativeSendMessage (no UAF).
+     *   3. wait up to [timeoutMs] for the drain so simple cases finish
+     *      synchronously; on timeout the deferred path still completes the close
+     *      later — the conversation is never freed while a send runs.
+     */
+    internal fun close(timeoutMs: Long) {
         XLog.i(TAG, "close() — closing conversation only (engine stays in EngineHolder)")
-        EngineHolder.withConversationSlot {
-            XLog.i(TAG, "[SESSION] SESSION_OWNER=TASK CONVERSATION_CLOSE")
-            try { conversation?.close() } catch (e: Exception) { XLog.w(TAG, "close conversation error", e) }
-            conversation = null
-            engine = null
-            processedMessageCount = 0
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var closeNow = false
+        synchronized(sendLifecycleLock) {
+            closing = true
+            if (inFlightSendCount == 0) {
+                closeNow = true            // fast path — no send running
+            } else {
+                closeDeferred = true       // endSend() will run the native close on the loop thread
+                XLog.i(TAG, "[SEND-GUARD] CLOSE_DEFERRED inFlight=$inFlightSendCount")
+                while (inFlightSendCount > 0) {
+                    val remaining = deadline - System.currentTimeMillis()
+                    if (remaining <= 0L) {
+                        XLog.w(TAG, "[SEND-GUARD] CLOSE_DEFER_TIMEOUT inFlight=$inFlightSendCount — " +
+                            "native close will run when the send finally drains; not blocking further")
+                        break
+                    }
+                    try {
+                        sendLifecycleLock.wait(remaining)
+                    } catch (ie: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        break  // deferred close still pending; do not force a native close now
+                    }
+                }
+            }
         }
+        if (closeNow) closeConversationNative()
         XLog.i(TAG, "close() — done")
     }
 
     companion object {
         private const val TAG = "LocalLlmClient"
+
+        /**
+         * Upper bound close() will wait for an in-flight native send to finish before
+         * it deletes the conversation. Gemma-4-E2B first prefill on CPU can exceed 90 s.
+         */
+        internal const val CLOSE_WAIT_TIMEOUT_MS = 120_000L
 
         private const val LOCAL_SYSTEM_PROMPT = """You control an Android phone via tools. Screen shows elements as: [n1] "text" [flags] (x,y) where n1 is the node ID and (x,y) is the tap target.
 

--- a/app/src/main/java/io/agents/pokeclaw/agent/llm/LocalLlmClient.kt
+++ b/app/src/main/java/io/agents/pokeclaw/agent/llm/LocalLlmClient.kt
@@ -80,21 +80,19 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
     private fun fallbackToCpu() {
         XLog.w(TAG, "fallbackToCpu: GPU inference failed, switching to CPU")
         gpuFailed = true
-        try { conversation?.close() } catch (_: Exception) {}
-        conversation = null
-        processedMessageCount = 0
-        sendCount = 0
-        engine = LocalModelRuntime.forceCpuEngine(ClawApplication.instance, config.baseUrl).engine
+        EngineHolder.withConversationSlot {
+            try { conversation?.close() } catch (_: Exception) {}
+            conversation = null
+            processedMessageCount = 0
+            sendCount = 0
+            engine = LocalModelRuntime.forceCpuEngine(ClawApplication.instance, config.baseUrl).engine
+        }
     }
 
     /**
      * Create a new conversation with system prompt and tool declarations.
      */
     private fun createConversation(systemPrompt: String, toolSpecs: List<ToolSpecification>) {
-        // LiteRT-LM only supports one session at a time — close existing first
-        try { conversation?.close() } catch (_: Exception) {}
-        conversation = null
-
         // Convert tool specs to native LiteRT-LM tools
         val nativeTools = toolSpecs.mapNotNull { spec ->
             try {
@@ -126,15 +124,27 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
             automaticToolCalling = false  // We handle execution in DefaultAgentService
         )
 
-        val lease = LocalModelRuntime.openConversation(
-            context = ClawApplication.instance,
-            modelPath = config.baseUrl,
-            conversationConfig = convConfig,
-            preferCpu = gpuFailed,
-        )
-        engine = lease.engine
-        conversation = lease.conversation
-        processedMessageCount = 0
+        // FIX 1 — close the old Conversation and open the new one atomically under the
+        // shared conversation-slot mutex, so the chat owner cannot open its own
+        // Conversation on the engine in the gap between our close and our open.
+        // The lock covers session lifecycle only — never the sendMessage/decode below.
+        EngineHolder.withConversationSlot {
+            XLog.i(TAG, "[SESSION] SESSION_OWNER=TASK CONVERSATION_CREATE_START tools=${nativeTools.size}")
+            // LiteRT-LM only supports one session at a time — close existing first
+            try { conversation?.close() } catch (_: Exception) {}
+            conversation = null
+
+            val lease = LocalModelRuntime.openConversation(
+                context = ClawApplication.instance,
+                modelPath = config.baseUrl,
+                conversationConfig = convConfig,
+                preferCpu = gpuFailed,
+            )
+            engine = lease.engine
+            conversation = lease.conversation
+            processedMessageCount = 0
+            XLog.i(TAG, "[SESSION] SESSION_OWNER=TASK CONVERSATION_CREATE_SUCCESS")
+        }
     }
 
     private var sendCount = 0
@@ -533,10 +543,13 @@ class LocalLlmClient(private val config: AgentConfig) : LlmClient {
 
     override fun close() {
         XLog.i(TAG, "close() — closing conversation only (engine stays in EngineHolder)")
-        try { conversation?.close() } catch (e: Exception) { XLog.w(TAG, "close conversation error", e) }
-        conversation = null
-        engine = null
-        processedMessageCount = 0
+        EngineHolder.withConversationSlot {
+            XLog.i(TAG, "[SESSION] SESSION_OWNER=TASK CONVERSATION_CLOSE")
+            try { conversation?.close() } catch (e: Exception) { XLog.w(TAG, "close conversation error", e) }
+            conversation = null
+            engine = null
+            processedMessageCount = 0
+        }
         XLog.i(TAG, "close() — done")
     }
 

--- a/app/src/main/java/io/agents/pokeclaw/agent/llm/LocalModelRuntime.kt
+++ b/app/src/main/java/io/agents/pokeclaw/agent/llm/LocalModelRuntime.kt
@@ -36,6 +36,17 @@ object LocalModelRuntime {
     private const val DEFAULT_RESET_ATTEMPT = 3
     private const val DEFAULT_RETRY_SLEEP_MS = 1500L
 
+    // FIX 3 — bounded session-conflict retry (safety net behind FIX 1 + FIX 2).
+    // A session conflict here is a transient race with the other session owner's
+    // Conversation teardown, not a permanent failure. Retry a small, fixed number
+    // of times with a short pause; never reset/recreate the engine; then fail closed.
+    internal const val SESSION_CONFLICT_MAX_ATTEMPTS = 3
+    internal const val SESSION_CONFLICT_RETRY_SLEEP_MS = 250L
+
+    /** Pure, unit-testable: given how many session-conflicts have occurred so far, retry? */
+    internal fun shouldRetrySessionConflict(priorAttempts: Int): Boolean =
+        priorAttempts < SESSION_CONFLICT_MAX_ATTEMPTS
+
     fun acquireSharedEngine(
         context: Context,
         modelPath: String,
@@ -85,21 +96,35 @@ object LocalModelRuntime {
     ): LocalConversationLease {
         var lastError: Exception? = null
         var forceCpu = preferCpu
+        var sessionConflicts = 0
 
         for (attempt in 1..maxRetries) {
             try {
-                val engineLease = acquireSharedEngine(context, modelPath, preferCpu = forceCpu)
-                val conversation = engineLease.engine.createConversation(conversationConfig)
-                return LocalConversationLease(
-                    engine = engineLease.engine,
-                    conversation = conversation,
-                    backendLabel = engineLease.backendLabel,
-                )
+                // FIX 1 — every engine.createConversation() on the shared engine goes
+                // through the conversation-slot mutex, whichever owner is calling.
+                // Reentrant: owners that already hold the slot (LocalLlmClient /
+                // ChatSessionController) simply re-enter here.
+                return EngineHolder.withConversationSlot {
+                    val engineLease = acquireSharedEngine(context, modelPath, preferCpu = forceCpu)
+                    val conversation = engineLease.engine.createConversation(conversationConfig)
+                    LocalConversationLease(
+                        engine = engineLease.engine,
+                        conversation = conversation,
+                        backendLabel = engineLease.backendLabel,
+                    )
+                }
             } catch (e: Exception) {
                 lastError = e
                 XLog.w(TAG, "openConversation attempt $attempt failed for $modelPath: ${e.message}")
 
                 if (isSessionConflict(e)) {
+                    sessionConflicts++
+                    if (shouldRetrySessionConflict(sessionConflicts)) {
+                        XLog.w(TAG, "SESSION_CONFLICT_RETRY attempt=$sessionConflicts/$SESSION_CONFLICT_MAX_ATTEMPTS")
+                        Thread.sleep(SESSION_CONFLICT_RETRY_SLEEP_MS)
+                        continue
+                    }
+                    XLog.e(TAG, "SESSION_CONFLICT_RETRY exhausted ($SESSION_CONFLICT_MAX_ATTEMPTS) — failing closed")
                     throw IllegalStateException("Local model session already in use", e)
                 }
 

--- a/app/src/main/java/io/agents/pokeclaw/automation/ExternalAutomationEntrypoint.kt
+++ b/app/src/main/java/io/agents/pokeclaw/automation/ExternalAutomationEntrypoint.kt
@@ -56,6 +56,13 @@ object ExternalAutomationEntrypoint {
             return false
         }
 
+        // FIX 2 — for a TASK, fence the chat side now: startActivity below brings
+        // ComposeChatActivity to the foreground and its onResume must not open a
+        // chat Conversation on the shared engine before the task claims it.
+        if (request.mode == ExternalAutomationContract.Mode.TASK) {
+            io.agents.pokeclaw.agent.llm.EngineHolder.markTaskStarting()
+        }
+
         XLog.i(TAG, "Accepted external automation ${request.mode}: ${request.text.take(MAX_LOG_TEXT)}")
         ExternalAutomationContract.sendCallback(
             context = context,

--- a/app/src/main/java/io/agents/pokeclaw/ui/chat/ChatSessionController.kt
+++ b/app/src/main/java/io/agents/pokeclaw/ui/chat/ChatSessionController.kt
@@ -11,6 +11,7 @@ import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.SystemMessage
 import dev.langchain4j.data.message.UserMessage
 import io.agents.pokeclaw.agent.ModelPricing
+import io.agents.pokeclaw.agent.llm.EngineHolder
 import io.agents.pokeclaw.agent.llm.LlmClient
 import io.agents.pokeclaw.agent.llm.LlmSessionManager
 import io.agents.pokeclaw.agent.llm.LocalModelManager
@@ -63,6 +64,23 @@ class ChatSessionController(
 
     fun isModelReady(): Boolean = isModelReady
 
+    /**
+     * FIX 2 — the chat side must NOT open a local Conversation while a task owns
+     * (or is about to own) the single shared model session.
+     *  - isTaskRunning(): authoritative once the orchestrator has the task lock —
+     *    covers the whole task, including long first prefills.
+     *  - EngineHolder.isTaskStarting(): covers the launch -> task-lock gap, during
+     *    which a task launch can already have brought this Activity to onResume.
+     */
+    private fun taskOwnsSession(): Boolean = isTaskRunning() || EngineHolder.isTaskStarting()
+
+    private fun deferChatOpenForTask(where: String) {
+        XLog.i(TAG, "[SESSION] SESSION_OWNER=CHAT open deferred at $where — TASK_ACTIVE_OR_STARTING=true")
+        uiState.modelStatus.value = "● Local task using model"
+        isModelReady = false
+        setButtonsEnabled(false)
+    }
+
     fun loadModelIfReady(
         conversationId: String? = null,
         visibleMessages: List<ChatMessage> = emptyList(),
@@ -110,10 +128,8 @@ class ChatSessionController(
 
         cloudClient = null
         val modelPath = resolvedConfig.local.modelPath
-        if (isTaskRunning()) {
-            uiState.modelStatus.value = "● Local task using model"
-            isModelReady = false
-            setButtonsEnabled(false)
+        if (taskOwnsSession()) {
+            deferChatOpenForTask("loadModelIfReady")
             return
         }
         XLog.d(TAG, "loadModelIfReady: stored=$modelPath loaded=$loadedModelPath engine=${engine != null}")
@@ -127,7 +143,7 @@ class ChatSessionController(
             loadedModelPath = null
             executor.submit {
                 try {
-                    oldConv?.close()
+                    EngineHolder.withConversationSlot { oldConv?.close() }
                 } catch (e: Exception) {
                     XLog.w(TAG, "loadModelIfReady: conv close error", e)
                 }
@@ -197,6 +213,13 @@ class ChatSessionController(
         conversationId: String,
         visibleMessages: List<ChatMessage>,
     ) {
+        // FIX 2 — if a task owns / is starting the session, do not touch the model
+        // here. The existing task-terminal callback re-runs syncUiToActiveModel()
+        // which reopens the chat session cleanly.
+        if (taskOwnsSession()) {
+            deferChatOpenForTask("onResume")
+            return
+        }
         syncUiToActiveModel()
         val currentModelPath = ModelConfigRepository.snapshot().local.modelPath
         if (currentModelPath.isNotEmpty() && currentModelPath != loadedModelPath) {
@@ -205,19 +228,26 @@ class ChatSessionController(
             val generation = ++localUiGeneration
             executor.submit {
                 try {
-                    try {
-                        conversation?.close()
-                    } catch (_: Exception) {
+                    if (taskOwnsSession()) {
+                        postToMain { deferChatOpenForTask("onResume/recreate") }
+                        return@submit
                     }
-                    conversation = null
-                    val lease = LocalModelRuntime.openConversation(
-                        activity,
-                        currentModelPath,
-                        buildConversationConfig(buildRestoredSystemPrompt(conversationId, visibleMessages))
-                    )
-                    engine = lease.engine
-                    conversation = lease.conversation
-                    isModelReady = true
+                    // FIX 1 — close + reopen atomically under the conversation-slot mutex.
+                    EngineHolder.withConversationSlot {
+                        try {
+                            conversation?.close()
+                        } catch (_: Exception) {
+                        }
+                        conversation = null
+                        val lease = LocalModelRuntime.openConversation(
+                            activity,
+                            currentModelPath,
+                            buildConversationConfig(buildRestoredSystemPrompt(conversationId, visibleMessages))
+                        )
+                        engine = lease.engine
+                        conversation = lease.conversation
+                        isModelReady = true
+                    }
                     postToMain {
                         if (!isLocalUiStillExpected(currentModelPath, generation)) {
                             return@postToMain
@@ -254,18 +284,71 @@ class ChatSessionController(
     }
 
     fun onPause(conversationId: String) {
-        if (engine != null && ConversationCompactor.needsCompaction(uiState.messages)) {
+        // FIX 2 — compaction opens a temporary Conversation on the shared engine;
+        // never do that while a task owns the session.
+        if (engine != null && !taskOwnsSession() && ConversationCompactor.needsCompaction(uiState.messages)) {
             executor.submit {
+                if (taskOwnsSession()) return@submit
+                // FIX 1 — close + compact (which opens a temp Conversation) under the slot.
+                EngineHolder.withConversationSlot {
+                    try {
+                        conversation?.close()
+                    } catch (_: Exception) {
+                    }
+                    conversation = null
+                    ConversationCompactor.compact(engine!!, uiState.messages, activity, conversationId)
+                    isModelReady = false
+                }
+            }
+        }
+        executor.submit {
+            EngineHolder.withConversationSlot {
                 try {
                     conversation?.close()
                 } catch (_: Exception) {
                 }
                 conversation = null
-                ConversationCompactor.compact(engine!!, uiState.messages, activity, conversationId)
                 isModelReady = false
             }
         }
+    }
+
+    fun onDestroy() {
         executor.submit {
+            XLog.i(TAG, "onDestroy: closing conversation (engine stays in EngineHolder)")
+            EngineHolder.withConversationSlot {
+                try {
+                    conversation?.close()
+                } catch (e: Exception) {
+                    XLog.w(TAG, "onDestroy: conversation close error", e)
+                }
+                conversation = null
+            }
+        }
+    }
+
+    /**
+     * Called from AppViewModel.onBeforeTask on the MAIN thread. Keep it cheap — do
+     * NOT hold the conversation-slot here (would risk blocking the UI thread).
+     * The real slot-guarded close happens in [prepareForTaskStart] on the chat
+     * executor, which TaskFlowController runs first.
+     */
+    fun releaseForTask() {
+        // FIX 2 — fence is up before any concurrent Activity.onResume can react.
+        EngineHolder.markTaskStarting()
+        try {
+            conversation?.close()
+        } catch (_: Exception) {
+        }
+        conversation = null
+        isModelReady = false
+    }
+
+    /** Called on the chat executor before a task starts. */
+    fun prepareForTaskStart() {
+        EngineHolder.markTaskStarting()
+        XLog.i(TAG, "[SESSION] SESSION_OWNER=CHAT CONVERSATION_CLOSE (prepareForTaskStart)")
+        EngineHolder.withConversationSlot {
             try {
                 conversation?.close()
             } catch (_: Exception) {
@@ -273,36 +356,6 @@ class ChatSessionController(
             conversation = null
             isModelReady = false
         }
-    }
-
-    fun onDestroy() {
-        executor.submit {
-            XLog.i(TAG, "onDestroy: closing conversation (engine stays in EngineHolder)")
-            try {
-                conversation?.close()
-            } catch (e: Exception) {
-                XLog.w(TAG, "onDestroy: conversation close error", e)
-            }
-            conversation = null
-        }
-    }
-
-    fun releaseForTask() {
-        try {
-            conversation?.close()
-        } catch (_: Exception) {
-        }
-        conversation = null
-        isModelReady = false
-    }
-
-    fun prepareForTaskStart() {
-        try {
-            conversation?.close()
-        } catch (_: Exception) {
-        }
-        conversation = null
-        isModelReady = false
     }
 
     fun sendChat(text: String) {
@@ -422,16 +475,23 @@ class ChatSessionController(
         }
 
         executor.submit {
-            try {
-                conversation?.close()
-            } catch (_: Exception) {
+            if (taskOwnsSession()) {
+                postToMain { deferChatOpenForTask("startNewConversationRuntime") }
+                return@submit
             }
-            val modelPath = ModelConfigRepository.snapshot().local.modelPath.ifEmpty { loadedModelPath.orEmpty() }
-            if (modelPath.isNotEmpty()) {
-                val lease = LocalModelRuntime.openConversation(activity, modelPath, buildConversationConfig())
-                engine = lease.engine
-                conversation = lease.conversation
-                isModelReady = true
+            // FIX 1 — close + open under the conversation-slot mutex.
+            EngineHolder.withConversationSlot {
+                try {
+                    conversation?.close()
+                } catch (_: Exception) {
+                }
+                val modelPath = ModelConfigRepository.snapshot().local.modelPath.ifEmpty { loadedModelPath.orEmpty() }
+                if (modelPath.isNotEmpty()) {
+                    val lease = LocalModelRuntime.openConversation(activity, modelPath, buildConversationConfig())
+                    engine = lease.engine
+                    conversation = lease.conversation
+                    isModelReady = true
+                }
             }
             postToMain {
                 addSystem("New conversation started.")
@@ -447,25 +507,32 @@ class ChatSessionController(
         }
         if (engine != null) {
             executor.submit {
+                if (taskOwnsSession()) {
+                    postToMain { deferChatOpenForTask("restoreConversationRuntime") }
+                    return@submit
+                }
                 try {
-                    try {
-                        conversation?.close()
-                    } catch (_: Exception) {
-                    }
                     val recentMsgs = messages.takeLast(5)
                     val systemPrompt = ConversationCompactor.buildRestoredSystemPrompt(activity, conversationId, recentMsgs)
                     val modelPath = ModelConfigRepository.snapshot().local.modelPath.ifEmpty { loadedModelPath.orEmpty() }
-                    val lease = LocalModelRuntime.openConversation(
-                        context = activity,
-                        modelPath = modelPath,
-                        conversationConfig = ConversationConfig(
-                            systemInstruction = Contents.of(systemPrompt),
-                            samplerConfig = SamplerConfig(topK = 64, topP = 0.95, temperature = 0.7)
+                    // FIX 1 — close + open under the conversation-slot mutex.
+                    EngineHolder.withConversationSlot {
+                        try {
+                            conversation?.close()
+                        } catch (_: Exception) {
+                        }
+                        val lease = LocalModelRuntime.openConversation(
+                            context = activity,
+                            modelPath = modelPath,
+                            conversationConfig = ConversationConfig(
+                                systemInstruction = Contents.of(systemPrompt),
+                                samplerConfig = SamplerConfig(topK = 64, topP = 0.95, temperature = 0.7)
+                            )
                         )
-                    )
-                    engine = lease.engine
-                    conversation = lease.conversation
-                    isModelReady = true
+                        engine = lease.engine
+                        conversation = lease.conversation
+                        isModelReady = true
+                    }
                     postToMain {
                         setButtonsEnabled(true)
                         addSystem("Conversation restored.")
@@ -484,22 +551,29 @@ class ChatSessionController(
         restoredSystemPrompt: String? = null,
     ) {
         try {
-            XLog.i(TAG, "loadModel: acquiring shared runtime for $modelPath")
-            try {
-                conversation?.close()
-            } catch (_: Exception) {
+            if (taskOwnsSession()) {
+                postToMain { deferChatOpenForTask("loadModel") }
+                return
             }
-            conversation = null
+            XLog.i(TAG, "loadModel: acquiring shared runtime for $modelPath")
             Thread.sleep(200)
+            // FIX 1 — close + open under the conversation-slot mutex.
+            EngineHolder.withConversationSlot {
+                try {
+                    conversation?.close()
+                } catch (_: Exception) {
+                }
+                conversation = null
 
-            val lease = LocalModelRuntime.openConversation(
-                activity,
-                modelPath,
-                buildConversationConfig(restoredSystemPrompt)
-            )
-            engine = lease.engine
-            XLog.i(TAG, "loadModel: engine ready (${lease.backendLabel})")
-            conversation = lease.conversation
+                val lease = LocalModelRuntime.openConversation(
+                    activity,
+                    modelPath,
+                    buildConversationConfig(restoredSystemPrompt)
+                )
+                engine = lease.engine
+                XLog.i(TAG, "loadModel: engine ready (${lease.backendLabel})")
+                conversation = lease.conversation
+            }
 
             isModelReady = true
             loadedModelPath = modelPath
@@ -540,21 +614,25 @@ class ChatSessionController(
 
     private fun retryLocalChatOnCpu(modelPath: String, text: String): String {
         require(modelPath.isNotEmpty()) { "Local model path missing for CPU retry" }
-        try {
-            conversation?.close()
-        } catch (_: Exception) {
+        // FIX 1 — session lifecycle (close old + force-CPU engine + open new) under
+        // the slot mutex; the sendMessage below runs OUTSIDE the lock.
+        EngineHolder.withConversationSlot {
+            try {
+                conversation?.close()
+            } catch (_: Exception) {
+            }
+            conversation = null
+            LocalModelRuntime.forceCpuEngine(activity, modelPath)
+            val lease = LocalModelRuntime.openConversation(
+                context = activity,
+                modelPath = modelPath,
+                conversationConfig = buildConversationConfig(),
+                preferCpu = true,
+            )
+            engine = lease.engine
+            loadedModelPath = modelPath
+            conversation = lease.conversation
         }
-        conversation = null
-        LocalModelRuntime.forceCpuEngine(activity, modelPath)
-        val lease = LocalModelRuntime.openConversation(
-            context = activity,
-            modelPath = modelPath,
-            conversationConfig = buildConversationConfig(),
-            preferCpu = true,
-        )
-        engine = lease.engine
-        loadedModelPath = modelPath
-        conversation = lease.conversation
         XLog.i(TAG, "retryLocalChatOnCpu: CPU runtime ready, retrying sendMessage")
         return conversation!!.sendMessage(text)?.toString() ?: "(no response)"
     }

--- a/app/src/test/java/io/agents/pokeclaw/agent/llm/CancelSafeCloseTest.kt
+++ b/app/src/test/java/io/agents/pokeclaw/agent/llm/CancelSafeCloseTest.kt
@@ -1,0 +1,162 @@
+// Copyright 2026 PokeClaw (agents.io). All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package io.agents.pokeclaw.agent.llm
+
+import io.agents.pokeclaw.agent.AgentConfig
+import io.agents.pokeclaw.agent.LlmProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Cancel-safe local-LLM close (experiment/pokeclaw-cancel-safe-close).
+ *
+ * The bug: close() → Conversation.close() → nativeDeleteConversation runs on
+ * another thread while the agent-loop thread is still inside
+ * Conversation.sendMessage → nativeSendMessage → use-after-free → SIGSEGV.
+ *
+ * These exercise the per-client in-flight send guard directly (no LiteRT-LM,
+ * no Android runtime): beginSend / endSend / close(timeoutMs).
+ */
+class CancelSafeCloseTest {
+
+    private fun newClient() =
+        LocalLlmClient(AgentConfig(apiKey = "", baseUrl = "/no/such/model", provider = LlmProvider.LOCAL))
+
+    // A — normal send lifecycle
+    @Test
+    fun `A - begin then end leaves no in-flight send`() {
+        val c = newClient()
+        c.beginSend()
+        assertEquals(1, c.inFlightSends)
+        c.endSend()
+        assertEquals(0, c.inFlightSends)
+        assertFalse(c.isClosing)
+        assertFalse(c.closeExecuted)
+    }
+
+    // B — close with no send in flight → native teardown happens synchronously
+    @Test
+    fun `B - close with no active send executes immediately`() {
+        val c = newClient()
+        c.close(5_000L)
+        assertTrue(c.isClosing)
+        assertTrue("native close ran", c.closeExecuted)
+    }
+
+    // C + D — cancel while a send is active: close must NOT tear down until the
+    // send finishes; when it finishes, the deferred close executes.
+    @Test
+    fun `C-D - close waits for the in-flight send, then executes on drain`() {
+        val c = newClient()
+        c.beginSend()   // simulate the loop thread inside nativeSendMessage
+
+        val closeReturned = CountDownLatch(1)
+        val t = Thread {
+            c.close(10_000L)   // generous timeout; should be released by endSend
+            closeReturned.countDown()
+        }
+        t.start()
+
+        // close() must still be blocked/deferred while the send is in flight
+        assertFalse("close returned before the send finished", closeReturned.await(400, TimeUnit.MILLISECONDS))
+        assertTrue(c.isClosing)
+        assertTrue(c.isCloseDeferred)
+        assertFalse("native close ran while a send was active (UAF!)", c.closeExecuted)
+
+        // send finishes → deferred close runs
+        c.endSend()
+        assertTrue("close() returned after drain", closeReturned.await(3, TimeUnit.SECONDS))
+        assertEquals(0, c.inFlightSends)
+        assertTrue("deferred native close executed", c.closeExecuted)
+        assertFalse(c.isCloseDeferred)
+    }
+
+    // E — a send started after close() must be rejected
+    @Test
+    fun `E - send after closing is rejected`() {
+        val c = newClient()
+        c.close(2_000L)
+        assertTrue(c.isClosing)
+        try {
+            c.beginSend()
+            fail("beginSend should have been rejected while closing")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("closing"))
+        }
+        assertEquals(0, c.inFlightSends)
+    }
+
+    // F — repeated close is idempotent and never throws
+    @Test
+    fun `F - repeated close is idempotent`() {
+        val c = newClient()
+        c.close(1_000L)
+        c.close(1_000L)
+        c.close(1_000L)
+        assertTrue(c.isClosing)
+        assertTrue(c.closeExecuted)
+    }
+
+    // G — close times out while a send is still running → it does NOT force a
+    // native close; the deferred close still runs later when the send drains.
+    @Test
+    fun `G - timeout does not force a native close`() {
+        val c = newClient()
+        c.beginSend()
+
+        val start = System.currentTimeMillis()
+        c.close(150L)   // short timeout, send still "running"
+        val elapsed = System.currentTimeMillis() - start
+
+        assertTrue("close returned near the timeout", elapsed in 100..2_000)
+        assertTrue(c.isClosing)
+        assertTrue("close is still pending", c.isCloseDeferred)
+        assertFalse("must NOT have torn down the conversation under an active send", c.closeExecuted)
+
+        // later, the send finishes → the deferred close finally runs
+        c.endSend()
+        assertTrue("deferred close executed after drain", c.closeExecuted)
+        assertEquals(0, c.inFlightSends)
+    }
+
+    // H — concurrency smoke: many begin/end pairs racing a close never leave
+    // the guard inconsistent and never run the native close early.
+    @Test
+    fun `H - concurrent sends racing a close stay consistent`() {
+        val c = newClient()
+        val workers = 6
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(workers)
+        repeat(workers) {
+            Thread {
+                start.await()
+                repeat(50) {
+                    try {
+                        c.beginSend()
+                        try { Thread.sleep(1) } finally { c.endSend() }
+                    } catch (_: IllegalStateException) {
+                        // closing — expected once close() has run
+                    }
+                }
+                done.countDown()
+            }.start()
+        }
+        val closer = Thread { start.await(); Thread.sleep(20); c.close(5_000L) }
+        closer.start()
+
+        start.countDown()
+        assertTrue(done.await(10, TimeUnit.SECONDS))
+        closer.join(5_000)
+
+        assertTrue(c.isClosing)
+        assertEquals("no leaked in-flight sends", 0, c.inFlightSends)
+        assertTrue("native close eventually executed", c.closeExecuted)
+        assertFalse(c.isCloseDeferred)
+    }
+}

--- a/app/src/test/java/io/agents/pokeclaw/agent/llm/SessionHandoffTest.kt
+++ b/app/src/test/java/io/agents/pokeclaw/agent/llm/SessionHandoffTest.kt
@@ -1,0 +1,167 @@
+// Copyright 2026 PokeClaw (agents.io). All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+package io.agents.pokeclaw.agent.llm
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Static / unit coverage for the local-model session-handoff fix
+ * (fix/experiment: serialize local model session handoff).
+ *
+ * These exercise the pieces that are Android-free:
+ *  - EngineHolder.withConversationSlot        (FIX 1 — lifecycle mutex)
+ *  - EngineHolder task-starting fence         (FIX 2 — task-active-or-starting)
+ *  - LocalModelRuntime session-conflict retry (FIX 3 — bounded retry)
+ */
+class SessionHandoffTest {
+
+    @Before
+    fun setUp() {
+        EngineHolder.clearTaskStarting()
+    }
+
+    @After
+    fun tearDown() {
+        EngineHolder.clearTaskStarting()
+    }
+
+    // ---------------------------------------------------------------
+    // A. chat open + task starting  ->  the fence reports "task owns session"
+    // ---------------------------------------------------------------
+    @Test
+    fun `A - fence is active while a task is starting`() {
+        assertFalse("no task -> not starting", EngineHolder.isTaskStarting())
+
+        EngineHolder.markTaskStarting()
+
+        // This is exactly what ChatSessionController.taskOwnsSession() consults
+        // before opening a chat Conversation.
+        assertTrue("task starting -> chat must defer", EngineHolder.isTaskStarting())
+    }
+
+    // ---------------------------------------------------------------
+    // B. task terminal  ->  fence cleared  ->  chat may reopen
+    // ---------------------------------------------------------------
+    @Test
+    fun `B - clearing the fence lets the chat side reopen`() {
+        EngineHolder.markTaskStarting()
+        assertTrue(EngineHolder.isTaskStarting())
+
+        EngineHolder.clearTaskStarting()
+
+        assertFalse("fence cleared -> chat open allowed", EngineHolder.isTaskStarting())
+    }
+
+    @Test
+    fun `B2 - starting fence auto-expires so a wedged launch cannot block chat forever`() {
+        val now = 10_000_000L
+        assertTrue(EngineHolder.startingFenceActive(now - 5_000L, now))
+        assertFalse(EngineHolder.startingFenceActive(now - (EngineHolder.TASK_STARTING_GRACE_MS + 1L), now))
+        assertFalse("zero timestamp = not set", EngineHolder.startingFenceActive(0L, now))
+    }
+
+    // ---------------------------------------------------------------
+    // C. two concurrent create attempts  ->  serialized by the slot mutex
+    // ---------------------------------------------------------------
+    @Test
+    fun `C - withConversationSlot serializes concurrent lifecycle blocks`() {
+        val inside = AtomicInteger(0)
+        val maxObserved = AtomicInteger(0)
+        val overlaps = AtomicInteger(0)
+        val threads = 8
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threads)
+
+        repeat(threads) {
+            Thread {
+                start.await()
+                EngineHolder.withConversationSlot {
+                    val n = inside.incrementAndGet()
+                    maxObserved.updateAndGet { m -> maxOf(m, n) }
+                    if (n > 1) overlaps.incrementAndGet()
+                    Thread.sleep(15)
+                    inside.decrementAndGet()
+                }
+                done.countDown()
+            }.start()
+        }
+
+        start.countDown()
+        assertTrue("threads finished", done.await(10, TimeUnit.SECONDS))
+        assertEquals("never more than one thread inside the slot", 1, maxObserved.get())
+        assertEquals("no overlap observed", 0, overlaps.get())
+    }
+
+    @Test
+    fun `C2 - withConversationSlot returns the block value and propagates exceptions`() {
+        assertEquals(42, EngineHolder.withConversationSlot { 42 })
+
+        var threw = false
+        try {
+            EngineHolder.withConversationSlot { throw IllegalStateException("boom") }
+        } catch (e: IllegalStateException) {
+            threw = true
+        }
+        assertTrue("exception propagates out of the slot", threw)
+        // slot is released even on exception — a following acquire must not deadlock
+        assertEquals("released after exception", 7, EngineHolder.withConversationSlot { 7 })
+    }
+
+    // ---------------------------------------------------------------
+    // D. session conflict  ->  at most SESSION_CONFLICT_MAX_ATTEMPTS tries
+    // ---------------------------------------------------------------
+    @Test
+    fun `D - bounded session-conflict retry caps at 3`() {
+        assertEquals(3, LocalModelRuntime.SESSION_CONFLICT_MAX_ATTEMPTS)
+        assertTrue("1st conflict -> retry", LocalModelRuntime.shouldRetrySessionConflict(1))
+        assertTrue("2nd conflict -> retry", LocalModelRuntime.shouldRetrySessionConflict(2))
+        assertFalse("3rd conflict -> fail closed", LocalModelRuntime.shouldRetrySessionConflict(3))
+        assertFalse("4th conflict -> fail closed", LocalModelRuntime.shouldRetrySessionConflict(4))
+    }
+
+    @Test
+    fun `D2 - the three known session-conflict messages are recognised`() {
+        assertTrue(LocalModelRuntime.isSessionConflict(RuntimeException("FAILED_PRECONDITION: A session already exists.")))
+        assertTrue(LocalModelRuntime.isSessionConflict(RuntimeException("Only one session is supported at a time")))
+        assertTrue(LocalModelRuntime.isSessionConflict(IllegalStateException("Local model session already in use")))
+    }
+
+    // ---------------------------------------------------------------
+    // E. non-session-conflict error  ->  NOT treated as a retryable conflict
+    // ---------------------------------------------------------------
+    @Test
+    fun `E - unrelated errors are not session conflicts`() {
+        assertFalse(LocalModelRuntime.isSessionConflict(RuntimeException("OpenCL init failed")))
+        assertFalse(LocalModelRuntime.isSessionConflict(RuntimeException("out of memory")))
+        assertFalse(LocalModelRuntime.isSessionConflict(null))
+        assertFalse(LocalModelRuntime.isSessionConflict(RuntimeException(null as String?)))
+    }
+
+    // ---------------------------------------------------------------
+    // F. fence must be cleared on FAIL / CANCEL too — TaskOrchestrator.releaseTask()
+    //    is the single chokepoint for every terminal and always calls clearTaskStarting().
+    //    Here we assert the primitive it relies on: clear is unconditional + idempotent.
+    // ---------------------------------------------------------------
+    @Test
+    fun `F - clearTaskStarting is unconditional and idempotent`() {
+        EngineHolder.markTaskStarting()
+        EngineHolder.clearTaskStarting()   // e.g. TaskEvent.Failed path
+        assertFalse(EngineHolder.isTaskStarting())
+
+        EngineHolder.clearTaskStarting()   // e.g. TaskEvent.Cancelled path, fence already down
+        assertFalse(EngineHolder.isTaskStarting())
+
+        // and a fresh task can still claim the fence afterwards
+        EngineHolder.markTaskStarting()
+        assertTrue(EngineHolder.isTaskStarting())
+    }
+}


### PR DESCRIPTION
Two on-device local-agent crashes on the LiteRT-LM path, plus regression tests.
No dependency, tool-registry, or model-specific behaviour changes.

## Bug 1 — competing Conversations on one Engine

`EngineHolder` keeps a single process-wide `Engine` shared by the chat UI
(`ChatSessionController`) and the task agent (`LocalLlmClient`). LiteRT-LM allows
exactly one live `Conversation` per `Engine`, but each owner opened its own with
no serialisation. When an external-automation task starts, it also brings
`ComposeChatActivity` to the foreground; `onResume` (chat) then races
`engine.createConversation()` on the task side and one throws:

    FAILED_PRECONDITION: A session already exists.
    Only one session is supported at a time.

Reproduces reliably when a chat conversation is already open at task start.

### Fix
- `EngineHolder.withConversationSlot { }` — a dedicated lock held **only** around
  conversation lifecycle (close old + open new). It is **never** held during
  `sendMessage` / prefill / decode.
- `EngineHolder` "task active or starting" fence
  (`markTaskStarting` / `clearTaskStarting` / `isTaskStarting`, ~15 s auto-expire).
  It covers the launch → task-lock window that `TaskSessionStore.isTaskRunning()`
  is too late for. Set from `AppViewModel.startTask` and
  `ExternalAutomationEntrypoint.handle` (TASK mode); cleared at the single
  terminal chokepoint `TaskOrchestrator.releaseTask()`.
- Every `ChatSessionController` path that opens a `Conversation`
  (`loadModelIfReady`, `onResume` recreate, `startNewConversationRuntime`,
  `restoreConversationRuntime`, `loadModel`, `onPause` compaction) defers
  cleanly while a task owns the session; the existing task-terminal callback
  reopens the chat session.
- `LocalModelRuntime.openConversation`: a session conflict is now a bounded,
  targeted retry (max 3, 250 ms apart, no engine reset) instead of an immediate
  fatal throw; fails closed after exhaustion.

## Bug 2 — conversation freed under an active native send

`DefaultAgentService.updateConfig()` / `shutdown()` (and a second task arriving
while one runs) call `LocalLlmClient.close()` → `Conversation.close()` →
`nativeDeleteConversation` from another thread while the agent-loop thread is
still inside `Conversation.sendMessage` → `nativeSendMessage`. The native send
is not interrupt-safe, so the conversation is deleted mid-flight:

    signal 11 (SIGSEGV), fault addr 0x0
      #01 liblitertlm_jni.so  Java_com_google_ai_edge_litertlm_LiteRtLmJni_nativeSendMessage+248
      #07 com.google.ai.edge.litertlm.Conversation.sendMessage
      #23 io.agents.pokeclaw.agent.llm.LocalLlmClient.chatInternal

### Fix (in `LocalLlmClient` only)
- `beginSend()` / `endSend()` bracket both native `conv.sendMessage()` sites and
  track `inFlightSendCount`.
- `close()` flips `closing`; `beginSend()` then rejects new sends so the loop
  stops (`DefaultAgentService` already sets `cancelled` before any `close()`).
- If a send is in flight, `close()` **defers** the native teardown — `endSend()`
  on the loop thread runs it once the last send drains. `close()` waits up to
  `CLOSE_WAIT_TIMEOUT_MS` (120 s) for a synchronous finish, then returns without
  ever calling `nativeDeleteConversation` under an active `nativeSendMessage`.
  On timeout it fails closed: the conversation is left alive rather than freed.

`nativeDeleteConversation` now only ever runs with `inFlightSendCount == 0`.

## Explicit invariants
- The conversation-lifecycle lock is **not** held during inference.
- The cancel path **never** calls `nativeDeleteConversation` while
  `nativeSendMessage` is active.

## Tests
- `SessionHandoffTest` — slot serialisation (8 threads, no overlap), fence
  set/clear/expiry/idempotency, bounded-retry cap, conflict-message matching.
- `CancelSafeCloseTest` — normal lifecycle, close-with-no-send, close waits then
  executes on drain (asserts no native close while a send is active),
  send-after-closing rejected, idempotent close, timeout does not force a native
  close, 6-thread concurrency.
- Full suite: 65/65 pass (16 new, 49 existing, 0 regressions).
- `testOptions.unitTests.isReturnDefaultValues = true` added so the new guard
  tests can run without Robolectric (they touch `android.util.Log` via `XLog`).

## Device validation
Gemma-4-E2B (`litert-community/gemma-4-E2B-it-litert-lm`), POCO F7 Pro / Android
16, CPU backend. Cold task, live-chat→task, cancel mid-`nativeSendMessage`,
task→chat, and three chat→task→cancel→chat cycles: 0 `FAILED_PRECONDITION`,
0 SIGSEGV, 0 leaked sessions, process stable, Chrome reaches foreground.

## Not changed
LiteRT-LM dependency (`com.google.ai.edge.litertlm:litertlm-android:0.10.0`),
`ToolRegistry`, model handling, `PromptUtils.applyGlobalPrompt`, any
model-specific behaviour, `applicationId`.
